### PR TITLE
DM-34921: The documentation for BPS plugins is missing from pipelines.lsst.io

### DIFF
--- a/doc/changes/DM-34921.doc.rst
+++ b/doc/changes/DM-34921.doc.rst
@@ -1,0 +1,1 @@
+Add missing __all__ statement to make the documentation render properly at https://pipelines.lsst.io.

--- a/python/lsst/ctrl/bps/panda/panda_service.py
+++ b/python/lsst/ctrl/bps/panda/panda_service.py
@@ -19,6 +19,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
+__all__ = ["PanDAService", "PandaBpsWmsWorkflow"]
+
+
 import binascii
 import concurrent.futures
 import logging


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
