### PR TITLE
DM-34653: propose to use PanDACache to ship user codes to remote sites (only for discuss, not merge)

### DIFF
--- a/python/lsst/ctrl/bps/panda/edgenode/cmd_line_decoder.py
+++ b/python/lsst/ctrl/bps/panda/edgenode/cmd_line_decoder.py
@@ -12,7 +12,6 @@ import re
 import sys
 import tarfile
 
-from pandaclient import Client
 from lsst.resources import ResourcePath
 
 
@@ -135,6 +134,9 @@ def deliver_input_files(src_path, files, skip_copy):
         archive_filename = src_path.replace("pandacache:", "")
         target_dir = os.getcwd()
         full_output_filename = os.path.join(target_dir, archive_filename)
+        if 'PANDACACHE_URL' not in os.environ:
+            os.environ['PANDACACHE_URL'] = os.environ['PANDA_URL_SSL']
+        from pandaclient import Client
         status, output = Client.getFile(archive_filename, output_path=full_output_filename, verbose=False)
         print("Download archive file from pandacache status: %s, output: %s" % (status, output))
         if status != 0:

--- a/python/lsst/ctrl/bps/panda/edgenode/cmd_line_decoder.py
+++ b/python/lsst/ctrl/bps/panda/edgenode/cmd_line_decoder.py
@@ -114,6 +114,63 @@ def deliver_input_files_origin(src_path, files, skip_copy):
                 print(f"copied {file_to_copy.path} " f"to {dest.path}", file=sys.stderr)
 
 
+def deliver_input_files_pandacache(src_path, files, skip_copy):
+    """Delivers input files needed for a job
+
+    Parameters
+    ----------
+    src_path : `str`
+        URI for folder where the input files placed
+    files : `str`
+        String with file names separated by the '+' sign
+
+    Returns
+    -------
+    cmdline: `str`
+        Processed command line
+        :param skip_copy:
+    """
+    pos = files.index("+")
+    archive_filename = files[:pos]
+    archive_filename = archive_filename.replace("pandacache:", "")
+    archive_basename = os.path.basename(archive_filename)
+    target_dir = os.getcwd()
+    full_output_filename = os.path.join(target_dir, archive_basename)
+    if "PANDACACHE_URL" not in os.environ and "PANDA_URL_SSL" in os.environ:
+        os.environ["PANDACACHE_URL"] = os.environ["PANDA_URL_SSL"]
+    else:
+        cache_dir = os.path.dirname(archive_filename)
+        os.environ["PANDACACHE_URL"] = os.path.dirname(cache_dir)
+    from pandaclient import Client
+    status, output = Client.getFile(archive_basename, output_path=full_output_filename, verbose=False)
+    print("Download archive file from pandacache status: %s, output: %s" % (status, output))
+    if status != 0:
+        raise RuntimeError("Failed to download archive file from pandacache")
+    with tarfile.open(full_output_filename, 'r:gz') as f:
+        f.extractall(target_dir)
+    os.remove(full_output_filename)
+
+    new_files = files[pos + 1:]
+
+    files = new_files.split("+")
+    dest_uri = ResourcePath(src_path, forceDirectory=True)
+    for file in files:
+        file_name_placeholder, file_pfn = file.split(":")
+        src_base = ResourcePath("", forceAbsolute=True, forceDirectory=True)
+        file_pfn = src_base.join(file_pfn)
+        if file_pfn.isdir():
+            files_to_copy = ResourcePath.findFileResources([file_pfn])
+            dest_dir = dest_uri.join(file_pfn)
+        else:
+            files_to_copy = [file_pfn]
+            dest_dir = dest_uri
+        for file_to_copy in files_to_copy:
+            dest = dest_dir.join(file_to_copy.basename())
+            if not dest.exists():
+                dest.transfer_from(file_to_copy, transfer="copy", overwrite=True)
+                print(f"copied {file_to_copy.path} " f"to {dest.path}", file=sys.stderr)
+
+
 def deliver_input_files(src_path, files, skip_copy):
     """Delivers input files needed for a job
 
@@ -130,47 +187,36 @@ def deliver_input_files(src_path, files, skip_copy):
         Processed command line
         :param skip_copy:
     """
-    if src_path.startswith("pandacache:"):
-        archive_filename = src_path.replace("pandacache:", "")
-        target_dir = os.getcwd()
-        full_output_filename = os.path.join(target_dir, archive_filename)
-        if 'PANDACACHE_URL' not in os.environ:
-            os.environ['PANDACACHE_URL'] = os.environ['PANDA_URL_SSL']
-        from pandaclient import Client
-        status, output = Client.getFile(archive_filename, output_path=full_output_filename, verbose=False)
-        print("Download archive file from pandacache status: %s, output: %s" % (status, output))
-        if status != 0:
-            raise RuntimeError("Failed to download archive file from pandacache")
-        with tarfile.open(full_output_filename, 'r:gz') as f:
-            f.extractall(target_dir)
-        os.remove(full_output_filename)
+    if files.startswith("pandacache:"):
+        deliver_input_files_pandacache(src_path, files, skip_copy)
     else:
         deliver_input_files_origin(src_path, files, skip_copy)
 
 
-def replace_pandacache_var(src_path, cmd_line):
+def replace_pandacache_var(files):
     """Replaces pandacache to remove it.
 
     Parameters
     ----------
-    src_path : `str`
-        URI for folder where the input files placed
-    cmd_line : `str`
-        Command line
+    files : `str`
+        String with file names separated by the '+' sign
 
     Returns
     -------
-    cmdline: `str`
-        Processed command line
+    files: `str`
+        Processed files by removing pandacache
     """
-    if src_path.startswith("pandacache:"):
-        cmd_line = cmd_line.replace("pandacache/", "")
-    return cmd_line
+    if files.startswith("pandacache:"):
+        pos = files.index("+")
+        files = files[pos + 1:]
+
+    return files
 
 
 deliver_input_files(sys.argv[3], sys.argv[4], sys.argv[5])
+sys.argv[4] = replace_pandacache_var(sys.argv[4])
+
 cmd_line = str(binascii.unhexlify(sys.argv[1]).decode())
-cmd_line = replace_pandacache_var(sys.argv[3], cmd_line)
 data_params = sys.argv[2].split("+")
 cmd_line = replace_environment_vars(cmd_line)
 

--- a/python/lsst/ctrl/bps/panda/panda_service.py
+++ b/python/lsst/ctrl/bps/panda/panda_service.py
@@ -355,7 +355,6 @@ class PanDAService(BaseWmsService):
         cache_path = os.path.join(os.environ["PANDACACHE_URL"], 'cache')
         filename = os.path.join(cache_path, filename)
         _LOG.info("Uploaded archive file %s to pandacache" % filename)
-        raise RuntimeError("stop")
         return filename
 
     def copy_files_to_pandacache_for_distribution(self, tasks, file_distribution_uri):


### PR DESCRIPTION
I developed some codes to ship user codes to remote sites. I tested it with bps submit, it works to upload user codes to panda cache. To test the cmd_line_decoder.py, I copied the command below from pilot logs and tested it locally, it works ok to download the source codes from panda cache and run the jobs. However the missing part is writing outputs. In this way, I think the outputs are written to local temp disks. I am not sure how to set arguments to let rubin to write outputs to somewhere else.

python3 ${CTRL_BPS_PANDA_DIR}/python/lsst/ctrl/bps/panda/edgenode/cmd_line_decoder.py 3c454e563a4354524c5f4d50455845435f4449523e2f62696e2f706970657461736b202d2d6c6f6e672d6c6f67202d2d6c6f672d6c6576656c3d564552424f5345202d2d6c6f672d66696c65207061796c6f61642d6c6f672e6a736f6e2072756e202d62203c46494c453a6275746c6572436f6e6669673e202d6920322e32692f64656661756c74732f746573742d6d65642d31202d6f20752f776775616e6963656465772f74696e79444332202d2d6f75747075742d72756e20752f776775616e6963656465772f74696e794443322f3230323230353235543039313435345a202d2d7167726170682070616e646163616368652f3c46494c453a72756e51677261706846696c653e202d2d7167726170682d6964207b71677261706849647d202d2d7167726170682d6e6f64652d6964207b7167726170684e6f646549647d202d2d636c6f626265722d6f757470757473202d2d696e69742d6f6e6c79202d2d657874656e642d72756e20 pipetaskInit+qgraphNodeId:540af2db-d641-49f6-994b-a2a9158fc89e,871c5dd0-b53f-437b-a695-295ab139efae,9d89875d-18d7-4741-a8ad-c0c5eb5c5c2f,cbcdb0eb-55a4-41ba-b9cd-0d7b05e8fdb6,db3429e2-b5d1-4a8e-91a1-d050fbd53b54+qgraphId:1653470123.7672892-6232 pandacache:jobO.ec51b7b0-ca4c-4449-b228-aa8a1ff7c9c3.tar.gz  runQgraphFile:u_wguanicedew_tinyDC2_20220525T091454Z.qgraph+butlerConfig:EXEC_REPO-u_wguanicedew_tinyDC2_20220525T091454Z/+None:final_job.bash runQgraphFile

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
