### PR TITLE
DM-35690: Require pip version less than 22

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Update pip/wheel infrastructure
         run: |
-          pip install --upgrade setuptools pip wheel
+          pip install --upgrade setuptools "pip<22" wheel
 
       - name: Install dependencies
         run: |
@@ -78,7 +78,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip<22"
           pip install --upgrade setuptools wheel build
 
       - name: Build and create distribution


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
