### PR TITLE
DM-35364: fix confusing message when authentication fails

### DIFF
--- a/doc/changes/DM-35364.bugfix.rst
+++ b/doc/changes/DM-35364.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the bug the bps-panda reports successful when there is an authentication permission error.

--- a/python/lsst/ctrl/bps/panda/panda_service.py
+++ b/python/lsst/ctrl/bps/panda/panda_service.py
@@ -335,7 +335,7 @@ class PanDAService(BaseWmsService):
                 status = True
                 result = ret[1][1]
                 error = None
-                if 'Authentication no permission' in result:
+                if "Authentication no permission" in result:
                     status = False
                     error = result
                     result = None

--- a/python/lsst/ctrl/bps/panda/panda_service.py
+++ b/python/lsst/ctrl/bps/panda/panda_service.py
@@ -337,8 +337,8 @@ class PanDAService(BaseWmsService):
                 error = None
                 if "Authentication no permission" in result:
                     status = False
-                    error = result
                     result = None
+                    error = result
             else:
                 # iDDS returns errors
                 status = False

--- a/python/lsst/ctrl/bps/panda/panda_service.py
+++ b/python/lsst/ctrl/bps/panda/panda_service.py
@@ -335,6 +335,10 @@ class PanDAService(BaseWmsService):
                 status = True
                 result = ret[1][1]
                 error = None
+                if 'Authentication no permission' in result:
+                    status = False
+                    error = result
+                    result = None
             else:
                 # iDDS returns errors
                 status = False


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
