### PR TITLE
DM-35964: fix the bug that idds result can be something other than a string

### DIFF
--- a/doc/changes/DM-35964.bugfix.rst
+++ b/doc/changes/DM-35964.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the bug that idds results can be something other than a string.

--- a/python/lsst/ctrl/bps/panda/panda_service.py
+++ b/python/lsst/ctrl/bps/panda/panda_service.py
@@ -335,7 +335,7 @@ class PanDAService(BaseWmsService):
                 status = True
                 result = ret[1][1]
                 error = None
-                if "Authentication no permission" in result:
+                if isinstance(result, str) and "Authentication no permission" in result:
                     status = False
                     result = None
                     error = result


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
